### PR TITLE
Fix JavaScript compression code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To encode a Monero Payment Request, follow these steps:
    
 2. Compress the JSON object using gzip compression. Set the modification time to a constant value to ensure consistency.
    - Python: `gzip.compress(data, mtime=0)`
-   - JavaScript: `pako.gzip(data, {mtime: 0})`  *(using pako library)*
+   - JavaScript: `pako.gzip(data, { level: 9, windowBits: 31 })`  *(using pako library)*
 
 3. Encode the compressed data in Base64 format.
    - Python: `base64.b64encode(data).decode('ascii')`


### PR DESCRIPTION
The correct parameters for `pako.gzip` are `level: 9, windowBits: 31`. This is equivalent to Python's `gzip.compress` with mtime=0.